### PR TITLE
Adding getopt.h library to do not create warning during the compilati…

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <getopt.h>
 
 #include "mnemonics.h"
 


### PR DESCRIPTION
Adding getopt.h library to do not create warning during the compilation with --std=c11 -pedantic GCC flags. Fix issue #34.